### PR TITLE
feat: consume public app config endpoint to replace hardcoded brand name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mycelium-webapp",
   "private": true,
-  "version": "0.5.0",
+  "version": "0.6.0",
   "scripts": {
     "dev": "vite --host",
     "build": "tsc -b && vite build",

--- a/src/hooks/use-app-config.ts
+++ b/src/hooks/use-app-config.ts
@@ -1,0 +1,20 @@
+import useSWR from "swr";
+
+import {
+  AppPublicConfig,
+  fetchAppPublicConfig,
+} from "@/services/app-config";
+
+export function useAppConfig() {
+  const { data, error } = useSWR<AppPublicConfig>(
+    "app-public-config",
+    fetchAppPublicConfig,
+    {
+      revalidateOnFocus: false,
+      revalidateOnReconnect: false,
+      revalidateIfStale: false,
+    }
+  );
+
+  return { appConfig: data, appConfigError: error };
+}

--- a/src/screens/HomePage/index.tsx
+++ b/src/screens/HomePage/index.tsx
@@ -21,6 +21,7 @@ import { setNotification } from "@/states/notification.state";
 import { useNativeAuthContext } from "@/contexts/NativeAuthContext";
 import { InvalidCodeError } from "@/types/NativeAuth";
 import useProfile from "@/hooks/use-profile";
+import { useAppConfig } from "@/hooks/use-app-config";
 
 type EmailForm = { email: string };
 type CodeForm = { code: string };
@@ -31,6 +32,7 @@ export default function HomePage() {
   const dispatch = useDispatch();
   const { setAuth } = useNativeAuthContext();
   const { isAuthenticated, isLoadingUser, logout } = useProfile();
+  const { appConfig } = useAppConfig();
 
   const [searchParams, setSearchParams] = useSearchParams();
   const step = (searchParams.get("step") as "email" | "code") ?? "email";
@@ -120,7 +122,7 @@ export default function HomePage() {
           {/* Brand */}
           <div className="flex flex-col gap-2 text-center">
             <Typography as="h1" decoration="bold" center>
-              {t(`${tHome}.hero.name`)}
+              {appConfig?.domainName ?? t(`${tHome}.hero.name`)}
             </Typography>
             <Typography as="p" decoration="smooth" center>
               {t(`${tHome}.hero.tagline`)}
@@ -277,7 +279,7 @@ export default function HomePage() {
                 className="block dark:hidden w-7 h-7 object-contain opacity-80"
               />
               <Typography as="p" decoration="smooth">
-                Mycelium API Gateway
+                {appConfig?.domainName ?? t(`${tHome}.hero.name`)}
               </Typography>
             </div>
             <div className="flex flex-col gap-2.5">
@@ -298,7 +300,7 @@ export default function HomePage() {
 
           <div className="flex flex-col justify-end">
             <Typography as="p" decoration="smooth">
-              Mycelium &copy; 2025
+              {appConfig?.domainName ?? t(`${tHome}.hero.name`)} &copy; 2025
             </Typography>
           </div>
         </div>

--- a/src/services/app-config.ts
+++ b/src/services/app-config.ts
@@ -1,0 +1,17 @@
+import { MYCELIUM_API_URL } from "@/services/openapi/mycelium-api";
+
+export interface AppPublicConfig {
+  domainName: string;
+  domainUrl: string | null;
+  locale: string | null;
+}
+
+export async function fetchAppPublicConfig(): Promise<AppPublicConfig> {
+  const res = await fetch(`${MYCELIUM_API_URL}/app-config`);
+
+  if (!res.ok) {
+    throw new Error(`Failed to fetch app config: ${res.status}`);
+  }
+
+  return res.json();
+}


### PR DESCRIPTION
## Summary

- Add `src/services/app-config.ts` — `fetchAppPublicConfig()` calls the new public `GET /app-config` gateway endpoint (no auth required) and returns `{ domainName, domainUrl, locale }`
- Add `src/hooks/use-app-config.ts` — `useAppConfig()` SWR hook with no-revalidate-on-focus/reconnect policy
- Update `HomePage` to use `appConfig.domainName` in three places that previously had hardcoded `"Mycelium API Gateway"` / `"Mycelium"`:
  - Hero section title
  - Footer brand name
  - Footer copyright line
- All three fall back to the existing i18n `screens.HomePage.hero.name` key while the request is in-flight or if the endpoint is unavailable
- Bump version `0.5.0` → `0.6.0`

## Depends on

Gateway PR: https://github.com/LepistaBioinformatics/mycelium/pull/158 (adds the `GET /app-config` endpoint)

## Test plan

- [ ] Home page title shows the value of `domainName` from gateway config (not "Mycelium API Gateway")
- [ ] Footer brand and copyright reflect the same value
- [ ] While API is loading, fallback i18n value is shown (no blank flicker)
- [ ] Build passes: `yarn build`
- [ ] Lint passes: `yarn lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)